### PR TITLE
Add "types" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "iteration",
     "iterator"
   ],
+  "types": "./dist/src/library.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rauschma/iterator-helpers-polyfill.git"


### PR DESCRIPTION
My vscode was not picking up the typings for the package after installation, even though it its written in TypeScript. Npm is not picking up the typings also, lists the package as untyped 
![fragment of the package's npm page, lacking the TS icon](https://user-images.githubusercontent.com/101339738/213256417-aaafba0f-8b70-476a-a566-00e8991fbdb8.png)
(note the lack of TS icon next to the package name)

The cause of that was a missing `"types"` field in the `package.json`. This PR hopefully fixes this issue.